### PR TITLE
Internationalization

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,39 @@
+body {
+  font-family: sans-serif;
+}
+table {
+  background-color: #f8f9fa;
+  color: #202122;
+  margin: 1em 0;
+  border: 1px solid #a2a9b1;
+  border-collapse: collapse;
+}
+th,
+td {
+  border: 1px solid #a2a9b1;
+  padding: 0.2em 0.4em;
+  color: #202122;
+  border-collapse: collapse;
+}
+th {
+  background-color: #eaecf0;
+  text-align: center;
+}
+a {
+  text-decoration: none;
+  color: #0645ad;
+  background: none;
+}
+.tell {
+  text-align: center;
+}
+nav ul,
+nav li {
+	display: inline;
+	margin: 0;
+	padding: 0;
+}
+nav li:not(:last-child)::after {
+	content: " ·";
+	font-weight: bold;
+}

--- a/templates/de.html
+++ b/templates/de.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <title>Ungesichtete globale Umbenennungen</title>
+    <link rel="stylesheet" href="/static/style.css">
+  </head>
+  <body>
+    <h1>Ungesichtete globale Umbenennungen</h1>
+    <p>Diese Seite zählt globale Dateiumbenennungen, die noch nicht <a href="https://de.wikipedia.org/wiki/Hilfe:Gesichtete_Versionen">gesichtet wurden</a>, auf. Im Moment gibt es {% if count == 1 %} eine Seite {% else %} {{ count }} Seiten {% endif %} auf dieser Liste.</p>
+    <table id="globalrename">
+      <tr>
+        <th>Artikel</th>
+        <th>Bearbeiter</th>
+        <th>Sichten</th>
+      </tr>
+      {% for row in rows %}
+      <tr>
+        <td><a href="{{ row.url }}" lang="{{ lang }}" hreflang="{{ lang }}">{{ row.title }}</a></td>
+        <td><bdi lang="">{{ row.renamer }}</bdi> {% if row.others %} + {{ row.others }} anderen {% endif %}</td>
+        <td class="tell"><a href="{{ row.reviewurl }}" hreflang="{{ lang }}">sichten</a></td>
+      </tr>
+      {% endfor %}
+    </table>
+    <footer>
+      <p><a href="https://github.com/fobewp/globalrenamereview/tree/main">Quellcode</a></p>
+      <nav>
+        Wikis:
+        <ul>
+          {% for dbname in dbnames %}
+          <li><a href="/{{ dbname }}" lang="zxx">{{ dbname }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/templates/en.html
+++ b/templates/en.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Unreviewed global file renames</title>
+    <link rel="stylesheet" href="/static/style.css">
+  </head>
+  <body>
+    <h1>Unreviewed global file renames</h1>
+    <p>This page lists global file renames that are <a href="https://www.mediawiki.org/wiki/Help:Extension:FlaggedRevs">pending review</a>. There {% if count == 1 %} is currently one page {% else %} are currently {{ count }} pages {% endif %} in this backlog.</p>
+    <table id="globalrename">
+      <tr>
+        <th>Article</th>
+        <th>Editor(s)</th>
+        <th>Review</th>
+      </tr>
+      {% for row in rows %}
+      <tr>
+        <td><a href="{{ row.url }}" lang="{{ lang }}" hreflang="{{ lang }}">{{ row.title }}</a></td>
+        <td><bdi lang="">{{ row.renamer }}</bdi> {% if row.others %} + {{ row.others }} others {% endif %}</td>
+        <td class="tell"><a href="{{ row.reviewurl }}" hreflang="{{ lang }}">review</a></td>
+      </tr>
+      {% endfor %}
+    </table>
+    <footer>
+      <p><a href="https://github.com/fobewp/globalrenamereview/tree/main">Source code</a></p>
+      <nav>
+        Wikis:
+        <ul>
+          {% for dbname in dbnames %}
+          <li><a href="/{{ dbname }}" lang="zxx">{{ dbname }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </footer>
+  </body>
+</html>

--- a/templates/hu.html
+++ b/templates/hu.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="hu">
+  <head>
+    <meta charset="utf-8">
+    <title>Ellenőrzésre váró globális fájlátnevezések</title>
+    <link rel="stylesheet" href="/static/style.css">
+  </head>
+  <body>
+    <h1>Ellenőrzésre váró globális fájlátnevezések</h1>
+    <p>Ez a lap az <a href="https://hu.wikipedia.org/wiki/Speci%C3%A1lis:Vand%C3%A1lsz%C5%B1r%C5%91/64">ellenőrzésre váró globális fájlátnevezéseket</a> listázza. Jelenleg {{ count }} ilyen lap vár ellenőrzésre.</p>
+    <table id="globalrename">
+      <tr>
+        <th>Cikk</th>
+        <th>Szerkesztő(k)</th>
+        <th>Ellenőrzés</th>
+      </tr>
+      {% for row in rows %}
+      <tr>
+        <td><a href="{{ row.url }}" lang="{{ lang }}" hreflang="{{ lang }}">{{ row.title }}</a></td>
+        <td><bdi lang="">{{ row.renamer }}</bdi> {% if row.others %} + {{ row.others }} további {% endif %}</td>
+        <td class="tell"><a href="{{ row.reviewurl }}" hreflang="{{ lang }}">ellenőriz</a></td>
+      </tr>
+      {% endfor %}
+    </table>
+    <footer>
+      <p><a href="https://github.com/fobewp/globalrenamereview/tree/main">Forráskód</a></p>
+      <nav>
+        Wikik:
+        <ul>
+          {% for dbname in dbnames %}
+          <li><a href="/{{ dbname }}" lang="zxx">{{ dbname }}</a></li>
+          {% endfor %}
+        </ul>
+      </nav>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
This adds support for three UI languages (English, German, Hungarian), as well as all FlaggedRevs wikis. To achieve the latter, it now uses the page history instead of an abuse filter rule (which exists only on huwiki). This makes the output longer: now all pages are reported that have pending global renames, even if the user is trusted on wiki, but their edit was not autoreviewed due to prior pending changes. (I think it also makes more sense.)

The UI localization is not the best solution (separate templates for each language, repeating the HTML code), but I don’t want to invest in a better but more complicated solution unless non-techy people want to participate in the translation.